### PR TITLE
feat(envs): migrate repo from nestjsx to rewiko

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -4,7 +4,7 @@ github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, u
 patreon: # Replace with a single Patreon username
 open_collective: nestjsx
 ko_fi: # Replace with a single Ko-fi username
-tidelift: npm/@nestjsx/crud
+tidelift: npm/@rewiko/crud
 community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
 liberapay: # Replace with a single Liberapay username
 issuehunt: # Replace with a single IssueHunt username

--- a/README.md
+++ b/README.md
@@ -8,20 +8,20 @@
 <br />
 
 <div align="center">
-  <a href="https://travis-ci.org/nestjsx/crud">
-    <img src="https://github.com/nestjsx/crud/workflows/Tests/badge.svg" alt="Build" />
+  <a href="https://travis-ci.org/rewiko/crud">
+    <img src="https://github.com/rewiko/crud/workflows/Tests/badge.svg" alt="Build" />
   </a>
-  <a href="https://coveralls.io/github/nestjsx/crud?branch=master">
-    <img src="https://coveralls.io/repos/github/nestjsx/crud/badge.svg" alt="Coverage" />
+  <a href="https://coveralls.io/github/rewiko/crud?branch=master">
+    <img src="https://coveralls.io/repos/github/rewiko/crud/badge.svg" alt="Coverage" />
   </a>
-  <a href="https://github.com/nestjsx/crud/blob/master/LICENSE">
-    <img src="https://img.shields.io/github/license/nestjsx/crud.svg" alt="License" />
+  <a href="https://github.com/rewiko/crud/blob/master/LICENSE">
+    <img src="https://img.shields.io/github/license/rewiko/crud.svg" alt="License" />
   </a>
-  <a href="https://www.npmjs.com/package/@nestjsx/crud">
-    <img src="https://img.shields.io/npm/v/@nestjsx/crud.svg" alt="npm version" />
+  <a href="https://www.npmjs.com/package/@rewiko/crud">
+    <img src="https://img.shields.io/npm/v/@rewiko/crud.svg" alt="npm version" />
   </a>
   <a href="https://www.npmjs.com/org/nestjsx">
-    <img src="https://img.shields.io/npm/dm/@nestjsx/crud.svg" alt="npm downloads" />
+    <img src="https://img.shields.io/npm/dm/@rewiko/crud.svg" alt="npm downloads" />
   </a>
   <a href="https://npm.packagequality.com/#?package=@nestjsx%2Fcrud">
     <img src="https://npm.packagequality.com/shield/%40nestjsx%2Fcrud.svg" alt="Package Quality" />
@@ -33,13 +33,13 @@
     <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square" alt="PRs welcome" />
   </a>
   <a href="https://github.com/marmelab/awesome-rest#nodejs">
-    <img src="https://raw.githubusercontent.com/nestjsx/crud/master/img/awesome-rest.svg?sanitize=true" alt="Awesome REST" />
+    <img src="https://raw.githubusercontent.com/rewiko/crud/master/img/awesome-rest.svg?sanitize=true" alt="Awesome REST" />
   </a>
   <a href="https://github.com/juliandavidmr/awesome-nestjs#components--libraries">
-    <img src="https://raw.githubusercontent.com/nestjsx/crud/master/img/awesome-nest.svg?sanitize=true" alt="Awesome Nest" />
+    <img src="https://raw.githubusercontent.com/rewiko/crud/master/img/awesome-nest.svg?sanitize=true" alt="Awesome Nest" />
   </a>
   <a href="https://github.com/nestjs/nest">
-    <img src="https://raw.githubusercontent.com/nestjsx/crud/master/img/nest-powered.svg?sanitize=true" alt="Nest Powered" />
+    <img src="https://raw.githubusercontent.com/rewiko/crud/master/img/nest-powered.svg?sanitize=true" alt="Nest Powered" />
   </a>
   <a href="#individuals" alt="Sponsors on Open Collective">
     <img src="https://opencollective.com/nestjsx/backers/badge.svg" />
@@ -52,7 +52,7 @@
 <div align="center">
   <sub>Built with :purple_heart: by
   <a href="https://twitter.com/MichaelYali">@MichaelYali</a> and
-  <a href="https://github.com/nestjsx/crud/graphs/contributors">
+  <a href="https://github.com/rewiko/crud/graphs/contributors">
     Contributors
   </a>
   <div align="center">
@@ -62,7 +62,7 @@
 
 <br />
 
-We believe that everyone who's working with NestJs and building some RESTful services and especially some CRUD functionality will find `@nestjsx/crud` microframework very useful.
+We believe that everyone who's working with NestJs and building some RESTful services and especially some CRUD functionality will find `@rewiko/crud` microframework very useful.
 
 ## Features
 
@@ -88,16 +88,16 @@ We believe that everyone who's working with NestJs and building some RESTful ser
 
 ## Packages
 
-- [**@nestjsx/crud**](https://www.npmjs.com/package/@nestjsx/crud) - core package which provides `@Crud()` decorator for endpoints generation, global configuration, validation, helper decorators ([docs](https://github.com/nestjsx/crud/wiki/Controllers#description))
-- [**@nestjsx/crud-request**](https://www.npmjs.com/package/@nestjsx/crud-request) - request builder/parser package which provides `RequestQueryBuilder` class for a frontend usage and `RequestQueryParser` that is being used internally for handling and validating query/path params on a backend side ([docs](https://github.com/nestjsx/crud/wiki/Requests#frontend-usage))
-- [**@nestjsx/crud-typeorm**](https://www.npmjs.com/package/@nestjsx/crud-typeorm) - TypeORM package which provides base `TypeOrmCrudService` with methods for CRUD database operations ([docs](https://github.com/nestjsx/crud/wiki/ServiceTypeorm))
+- [**@rewiko/crud**](https://www.npmjs.com/package/@rewiko/crud) - core package which provides `@Crud()` decorator for endpoints generation, global configuration, validation, helper decorators ([docs](https://github.com/rewiko/crud/wiki/Controllers#description))
+- [**@rewiko/crud-request**](https://www.npmjs.com/package/@rewiko/crud-request) - request builder/parser package which provides `RequestQueryBuilder` class for a frontend usage and `RequestQueryParser` that is being used internally for handling and validating query/path params on a backend side ([docs](https://github.com/rewiko/crud/wiki/Requests#frontend-usage))
+- [**@rewiko/crud-typeorm**](https://www.npmjs.com/package/@rewiko/crud-typeorm) - TypeORM package which provides base `TypeOrmCrudService` with methods for CRUD database operations ([docs](https://github.com/rewiko/crud/wiki/ServiceTypeorm))
 
 ## Documentation
 
-- :dart: [General Information](https://github.com/nestjsx/crud/wiki#why)
-- :video_game: [CRUD Controllers](https://github.com/nestjsx/crud/wiki/Controllers#description)
-- :horse_racing: [CRUD ORM Services](https://github.com/nestjsx/crud/wiki/Services#description)
-- :trumpet: [Handling Requests](https://github.com/nestjsx/crud/wiki/Requests#description)
+- :dart: [General Information](https://github.com/rewiko/crud/wiki#why)
+- :video_game: [CRUD Controllers](https://github.com/rewiko/crud/wiki/Controllers#description)
+- :horse_racing: [CRUD ORM Services](https://github.com/rewiko/crud/wiki/Services#description)
+- :trumpet: [Handling Requests](https://github.com/rewiko/crud/wiki/Requests#description)
 
 ## Support
 
@@ -108,7 +108,7 @@ Any support is welcome. At least you can give us a star :star:
 ### Code Contributors
 
 This project exists thanks to all the people who contribute. [[Contribute](CODE_OF_CONDUCT.md)].
-<a href="https://github.com/nestjsx/crud/graphs/contributors"><img src="https://opencollective.com/nestjsx/contributors.svg?width=890&button=false" /></a>
+<a href="https://github.com/rewiko/crud/graphs/contributors"><img src="https://opencollective.com/nestjsx/contributors.svg?width=890&button=false" /></a>
 
 ### Financial Contributors
 

--- a/integration/crud-typeorm/companies/companies.controller.ts
+++ b/integration/crud-typeorm/companies/companies.controller.ts
@@ -1,6 +1,6 @@
 import { Controller } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { Crud } from '@nestjsx/crud';
+import { Crud } from '@rewiko/crud';
 
 import { Company } from './company.entity';
 import { CompaniesService } from './companies.service';

--- a/integration/crud-typeorm/companies/companies.service.ts
+++ b/integration/crud-typeorm/companies/companies.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { TypeOrmCrudService } from '@nestjsx/crud-typeorm';
+import { TypeOrmCrudService } from '@rewiko/crud-typeorm';
 
 import { Company } from './company.entity';
 

--- a/integration/crud-typeorm/companies/company.entity.ts
+++ b/integration/crud-typeorm/companies/company.entity.ts
@@ -1,4 +1,4 @@
-import { CrudValidationGroups } from '@nestjsx/crud';
+import { CrudValidationGroups } from '@rewiko/crud';
 import { Entity, Column, OneToMany, PrimaryGeneratedColumn, DeleteDateColumn } from 'typeorm';
 import {
   IsOptional,

--- a/integration/crud-typeorm/companies/responses/index.ts
+++ b/integration/crud-typeorm/companies/responses/index.ts
@@ -1,4 +1,4 @@
-import { SerializeOptions } from '@nestjsx/crud';
+import { SerializeOptions } from '@rewiko/crud';
 import { GetCompanyResponseDto } from './get-company-response.dto';
 
 export const serialize: SerializeOptions = {

--- a/integration/crud-typeorm/devices/device.entity.ts
+++ b/integration/crud-typeorm/devices/device.entity.ts
@@ -1,6 +1,6 @@
 import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
 import { IsOptional, IsString, IsUUID } from 'class-validator';
-import { CrudValidationGroups } from '@nestjsx/crud';
+import { CrudValidationGroups } from '@rewiko/crud';
 
 const { CREATE, UPDATE } = CrudValidationGroups;
 

--- a/integration/crud-typeorm/devices/devices.controller.ts
+++ b/integration/crud-typeorm/devices/devices.controller.ts
@@ -1,6 +1,6 @@
 import { Controller } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { Crud } from '@nestjsx/crud';
+import { Crud } from '@rewiko/crud';
 
 import { Device } from './device.entity';
 import { DevicesService } from './devices.service';

--- a/integration/crud-typeorm/devices/devices.service.ts
+++ b/integration/crud-typeorm/devices/devices.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { TypeOrmCrudService } from '@nestjsx/crud-typeorm';
+import { TypeOrmCrudService } from '@rewiko/crud-typeorm';
 
 import { Device } from './device.entity';
 

--- a/integration/crud-typeorm/devices/response/index.ts
+++ b/integration/crud-typeorm/devices/response/index.ts
@@ -1,4 +1,4 @@
-import { SerializeOptions } from '@nestjsx/crud';
+import { SerializeOptions } from '@rewiko/crud';
 import { DeleteDeviceResponseDto } from './delete-device-response.dto';
 
 export const serialize: SerializeOptions = {

--- a/integration/crud-typeorm/main.ts
+++ b/integration/crud-typeorm/main.ts
@@ -1,10 +1,10 @@
 import { NestFactory } from '@nestjs/core';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
-import { CrudConfigService } from '@nestjsx/crud';
+import { CrudConfigService } from '@rewiko/crud';
 import { USER_REQUEST_KEY } from './constants';
 
 // Important: load config before (!!!) you import AppModule
-// https://github.com/nestjsx/crud/wiki/Controllers#global-options
+// https://github.com/rewiko/crud/wiki/Controllers#global-options
 CrudConfigService.load({
   auth: {
     property: USER_REQUEST_KEY,
@@ -23,8 +23,8 @@ async function bootstrap() {
   app.useGlobalFilters(new HttpExceptionFilter());
 
   const options = new DocumentBuilder()
-    .setTitle('@nestjsx/crud-typeorm')
-    .setDescription('@nestjsx/crud-typeorm')
+    .setTitle('@rewiko/crud-typeorm')
+    .setDescription('@rewiko/crud-typeorm')
     .setVersion('1.0')
     .build();
   const document = SwaggerModule.createDocument(app, options);

--- a/integration/crud-typeorm/notes/notes.controller.ts
+++ b/integration/crud-typeorm/notes/notes.controller.ts
@@ -1,6 +1,6 @@
 import { Controller } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { Crud } from '@nestjsx/crud';
+import { Crud } from '@rewiko/crud';
 
 import { Note } from './note.entity';
 import { NotesService } from './notes.service';

--- a/integration/crud-typeorm/orm.config.ts
+++ b/integration/crud-typeorm/orm.config.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
-import { isNil } from '@nestjsx/util';
+import { isNil } from '@rewiko/util';
 
 const type = (process.env.TYPEORM_CONNECTION as any) || 'postgres';
 

--- a/integration/crud-typeorm/projects/my-projects.controller.ts
+++ b/integration/crud-typeorm/projects/my-projects.controller.ts
@@ -1,6 +1,6 @@
 import { Controller } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { Crud, CrudAuth } from '@nestjsx/crud';
+import { Crud, CrudAuth } from '@rewiko/crud';
 
 import { User } from '../users/user.entity';
 import { UserProject } from './user-project.entity';

--- a/integration/crud-typeorm/projects/project.entity.ts
+++ b/integration/crud-typeorm/projects/project.entity.ts
@@ -7,7 +7,7 @@ import {
   IsDefined,
   IsBoolean,
 } from 'class-validator';
-import { CrudValidationGroups } from '@nestjsx/crud';
+import { CrudValidationGroups } from '@rewiko/crud';
 
 import { BaseEntity } from '../base-entity';
 import { Company } from '../companies/company.entity';

--- a/integration/crud-typeorm/projects/projects.controller.ts
+++ b/integration/crud-typeorm/projects/projects.controller.ts
@@ -1,6 +1,6 @@
 import { Controller } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { Crud } from '@nestjsx/crud';
+import { Crud } from '@rewiko/crud';
 
 import { Project } from './project.entity';
 import { ProjectsService } from './projects.service';

--- a/integration/crud-typeorm/projects/projects.service.ts
+++ b/integration/crud-typeorm/projects/projects.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { TypeOrmCrudService } from '@nestjsx/crud-typeorm';
+import { TypeOrmCrudService } from '@rewiko/crud-typeorm';
 
 import { Project } from './project.entity';
 

--- a/integration/crud-typeorm/projects/user-projects.service.ts
+++ b/integration/crud-typeorm/projects/user-projects.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { TypeOrmCrudService } from '@nestjsx/crud-typeorm';
+import { TypeOrmCrudService } from '@rewiko/crud-typeorm';
 
 import { UserProject } from './user-project.entity';
 

--- a/integration/crud-typeorm/seeds.ts
+++ b/integration/crud-typeorm/seeds.ts
@@ -1,4 +1,4 @@
-import { ClassType } from '@nestjsx/util';
+import { ClassType } from '@rewiko/util';
 import { plainToClass } from 'class-transformer';
 import { MigrationInterface, Repository, QueryRunner } from 'typeorm';
 import { Company } from './companies';

--- a/integration/crud-typeorm/users/me.controller.ts
+++ b/integration/crud-typeorm/users/me.controller.ts
@@ -1,6 +1,6 @@
 import { Controller } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { Crud, CrudAuth } from '@nestjsx/crud';
+import { Crud, CrudAuth } from '@rewiko/crud';
 
 import { User } from './user.entity';
 import { UsersService } from './users.service';

--- a/integration/crud-typeorm/users/user.entity.ts
+++ b/integration/crud-typeorm/users/user.entity.ts
@@ -18,7 +18,7 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { Type } from 'class-transformer';
-import { CrudValidationGroups } from '@nestjsx/crud';
+import { CrudValidationGroups } from '@rewiko/crud';
 
 import { BaseEntity } from '../base-entity';
 import { UserProfile } from '../users-profiles/user-profile.entity';

--- a/integration/crud-typeorm/users/users.controller.ts
+++ b/integration/crud-typeorm/users/users.controller.ts
@@ -6,7 +6,7 @@ import {
   CrudRequest,
   ParsedRequest,
   Override,
-} from '@nestjsx/crud';
+} from '@rewiko/crud';
 
 import { User } from './user.entity';
 import { UsersService } from './users.service';

--- a/integration/crud-typeorm/users/users.service.ts
+++ b/integration/crud-typeorm/users/users.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { TypeOrmCrudService } from '@nestjsx/crud-typeorm';
+import { TypeOrmCrudService } from '@rewiko/crud-typeorm';
 
 import { User } from './user.entity';
 

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -5,7 +5,7 @@ const names = ['util', 'crud-request', 'crud', 'crud-typeorm'];
 
 const getBuildCmd = (pkg) => {
   const str = 'npx lerna run build';
-  const scoped = (name) => `--scope @nestjsx/${name}`;
+  const scoped = (name) => `--scope @rewiko/${name}`;
   return pkg ? `${str} ${scoped(pkg)}` : getSeries(names.map((name) => `build.${name}`));
 };
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nestjsx/crud",
+  "name": "@rewiko/crud",
   "version": "4.0.0",
   "description": "Nest CRUD for RESTful APIs",
   "license": "MIT",

--- a/packages/crud-request/README.md
+++ b/packages/crud-request/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <h1>CRUD (@nestjsx/crud-request)</h1>
+  <h1>CRUD (@rewiko/crud-request)</h1>
 </div>
 <div align="center">
   <strong>for RESTful APIs built with NestJs</strong>
@@ -8,20 +8,20 @@
 <br />
 
 <div align="center">
-  <a href="https://travis-ci.org/nestjsx/crud">
-    <img src="https://github.com/nestjsx/crud/workflows/Tests/badge.svg" alt="Build" />
+  <a href="https://travis-ci.org/rewiko/crud">
+    <img src="https://github.com/rewiko/crud/workflows/Tests/badge.svg" alt="Build" />
   </a>
-  <a href="https://coveralls.io/github/nestjsx/crud?branch=master">
-    <img src="https://coveralls.io/repos/github/nestjsx/crud/badge.svg" alt="Coverage" />
+  <a href="https://coveralls.io/github/rewiko/crud?branch=master">
+    <img src="https://coveralls.io/repos/github/rewiko/crud/badge.svg" alt="Coverage" />
   </a>
-  <a href="https://github.com/nestjsx/crud/blob/master/LICENSE">
-    <img src="https://img.shields.io/github/license/nestjsx/crud.svg" alt="License" />
+  <a href="https://github.com/rewiko/crud/blob/master/LICENSE">
+    <img src="https://img.shields.io/github/license/rewiko/crud.svg" alt="License" />
   </a>
-  <a href="https://www.npmjs.com/package/@nestjsx/crud">
-    <img src="https://img.shields.io/npm/v/@nestjsx/crud.svg" alt="npm version" />
+  <a href="https://www.npmjs.com/package/@rewiko/crud">
+    <img src="https://img.shields.io/npm/v/@rewiko/crud.svg" alt="npm version" />
   </a>
   <a href="https://www.npmjs.com/org/nestjsx">
-    <img src="https://img.shields.io/npm/dm/@nestjsx/crud.svg" alt="npm downloads" />
+    <img src="https://img.shields.io/npm/dm/@rewiko/crud.svg" alt="npm downloads" />
   </a>
   <a href="https://npm.packagequality.com/#?package=@nestjsx%2Fcrud">
     <img src="https://npm.packagequality.com/shield/%40nestjsx%2Fcrud.svg" alt="Package Quality" />
@@ -33,13 +33,13 @@
     <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square" alt="PRs welcome" />
   </a>
   <a href="https://github.com/marmelab/awesome-rest#nodejs">
-    <img src="https://raw.githubusercontent.com/nestjsx/crud/master/img/awesome-rest.svg?sanitize=true" alt="Awesome REST" />
+    <img src="https://raw.githubusercontent.com/rewiko/crud/master/img/awesome-rest.svg?sanitize=true" alt="Awesome REST" />
   </a>
   <a href="https://github.com/juliandavidmr/awesome-nestjs#components--libraries">
-    <img src="https://raw.githubusercontent.com/nestjsx/crud/master/img/awesome-nest.svg?sanitize=true" alt="Awesome Nest" />
+    <img src="https://raw.githubusercontent.com/rewiko/crud/master/img/awesome-nest.svg?sanitize=true" alt="Awesome Nest" />
   </a>
   <a href="https://github.com/nestjs/nest">
-    <img src="https://raw.githubusercontent.com/nestjsx/crud/master/img/nest-powered.svg?sanitize=true" alt="Nest Powered" />
+    <img src="https://raw.githubusercontent.com/rewiko/crud/master/img/nest-powered.svg?sanitize=true" alt="Nest Powered" />
   </a>
   <a href="#individuals" alt="Sponsors on Open Collective">
     <img src="https://opencollective.com/nestjsx/backers/badge.svg" />
@@ -52,18 +52,18 @@
 <div align="center">
   <sub>Built by
   <a href="https://twitter.com/MichaelYali">@MichaelYali</a> and
-  <a href="https://github.com/nestjsx/crud/graphs/contributors">
+  <a href="https://github.com/rewiko/crud/graphs/contributors">
     Contributors
   </a>
 </div>
 
 <br />
 
-We believe that everyone who's working with NestJs and building some RESTful services and especially some CRUD functionality will find `@nestjsx/crud` microframework very useful.
+We believe that everyone who's working with NestJs and building some RESTful services and especially some CRUD functionality will find `@rewiko/crud` microframework very useful.
 
 ## Features
 
-<img align="right" src="https://raw.githubusercontent.com/nestjsx/crud/master/img/crud-usage2.png" alt="CRUD usage" />
+<img align="right" src="https://raw.githubusercontent.com/rewiko/crud/master/img/crud-usage2.png" alt="CRUD usage" />
 
 - Super easy to install and start using the full-featured controllers and services :point_right:
 
@@ -86,21 +86,21 @@ We believe that everyone who's working with NestJs and building some RESTful ser
 ## Install
 
 ```shell
-npm i @nestjsx/crud-request
+npm i @rewiko/crud-request
 ```
 
 ## Packages
 
-- [**@nestjsx/crud**](https://www.npmjs.com/package/@nestjsx/crud) - core package which provides `@Crud()` decorator for endpoints generation, global configuration, validation, helper decorators ([docs](https://github.com/nestjsx/crud/wiki/Controllers#description))
-- [**@nestjsx/crud-request**](https://www.npmjs.com/package/@nestjsx/crud-request) - request builder/parser package which provides `RequestQueryBuilder` class for a frontend usage and `RequestQueryParser` that is being used internally for handling and validating query/path params on a backend side ([docs](https://github.com/nestjsx/crud/wiki/Requests#frontend-usage))
-- [**@nestjsx/crud-typeorm**](https://www.npmjs.com/package/@nestjsx/crud-typeorm) - TypeORM package which provides base `TypeOrmCrudService` with methods for CRUD database operations ([docs](https://github.com/nestjsx/crud/wiki/ServiceTypeorm))
+- [**@rewiko/crud**](https://www.npmjs.com/package/@rewiko/crud) - core package which provides `@Crud()` decorator for endpoints generation, global configuration, validation, helper decorators ([docs](https://github.com/rewiko/crud/wiki/Controllers#description))
+- [**@rewiko/crud-request**](https://www.npmjs.com/package/@rewiko/crud-request) - request builder/parser package which provides `RequestQueryBuilder` class for a frontend usage and `RequestQueryParser` that is being used internally for handling and validating query/path params on a backend side ([docs](https://github.com/rewiko/crud/wiki/Requests#frontend-usage))
+- [**@rewiko/crud-typeorm**](https://www.npmjs.com/package/@rewiko/crud-typeorm) - TypeORM package which provides base `TypeOrmCrudService` with methods for CRUD database operations ([docs](https://github.com/rewiko/crud/wiki/ServiceTypeorm))
 
 ## Documentation
 
-- [General Information](https://github.com/nestjsx/crud/wiki#why)
-- [CRUD Controllers](https://github.com/nestjsx/crud/wiki/Controllers#description)
-- [CRUD ORM Services](https://github.com/nestjsx/crud/wiki/Services#description)
-- [Handling Requests](https://github.com/nestjsx/crud/wiki/Requests#description)
+- [General Information](https://github.com/rewiko/crud/wiki#why)
+- [CRUD Controllers](https://github.com/rewiko/crud/wiki/Controllers#description)
+- [CRUD ORM Services](https://github.com/rewiko/crud/wiki/Services#description)
+- [Handling Requests](https://github.com/rewiko/crud/wiki/Requests#description)
 
 ## Support
 
@@ -111,7 +111,7 @@ Any support is welcome. At least you can give us a star.
 ### Code Contributors
 
 This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
-<a href="https://github.com/nestjsx/crud/graphs/contributors"><img src="https://opencollective.com/nestjsx/contributors.svg?width=890&button=false" /></a>
+<a href="https://github.com/rewiko/crud/graphs/contributors"><img src="https://opencollective.com/nestjsx/contributors.svg?width=890&button=false" /></a>
 
 ### Financial Contributors
 

--- a/packages/crud-request/src/interfaces/parsed-request.interface.ts
+++ b/packages/crud-request/src/interfaces/parsed-request.interface.ts
@@ -1,4 +1,4 @@
-import { ObjectLiteral } from '@nestjsx/util';
+import { ObjectLiteral } from '@rewiko/util';
 import { QueryFields, QueryFilter, QueryJoin, QuerySort, SCondition } from '../types';
 
 export interface ParsedRequestParams {

--- a/packages/crud-request/src/request-query.builder.ts
+++ b/packages/crud-request/src/request-query.builder.ts
@@ -5,7 +5,7 @@ import {
   isArrayFull,
   isNil,
   isUndefined,
-} from '@nestjsx/util';
+} from '@rewiko/util';
 import { stringify } from 'qs';
 
 import { RequestQueryBuilderOptions, CreateQueryParams } from './interfaces';

--- a/packages/crud-request/src/request-query.parser.ts
+++ b/packages/crud-request/src/request-query.parser.ts
@@ -10,7 +10,7 @@ import {
   objKeys,
   isNil,
   ObjectLiteral,
-} from '@nestjsx/util';
+} from '@rewiko/util';
 
 import { RequestQueryException } from './exceptions';
 import {

--- a/packages/crud-request/src/request-query.validator.ts
+++ b/packages/crud-request/src/request-query.validator.ts
@@ -7,7 +7,7 @@ import {
   isNumber,
   isNil,
   objKeys,
-} from '@nestjsx/util';
+} from '@rewiko/util';
 
 import { RequestQueryException } from './exceptions';
 import { ParamsOptions, ParamOption } from './interfaces';

--- a/packages/crud-typeorm/README.md
+++ b/packages/crud-typeorm/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <h1>CRUD (@nestjsx/crud-typeorm)</h1>
+  <h1>CRUD (@rewiko/crud-typeorm)</h1>
 </div>
 <div align="center">
   <strong>for RESTful APIs built with NestJs</strong>
@@ -8,20 +8,20 @@
 <br />
 
 <div align="center">
-  <a href="https://travis-ci.org/nestjsx/crud">
-    <img src="https://github.com/nestjsx/crud/workflows/Tests/badge.svg" alt="Build" />
+  <a href="https://travis-ci.org/rewiko/crud">
+    <img src="https://github.com/rewiko/crud/workflows/Tests/badge.svg" alt="Build" />
   </a>
-  <a href="https://coveralls.io/github/nestjsx/crud?branch=master">
-    <img src="https://coveralls.io/repos/github/nestjsx/crud/badge.svg" alt="Coverage" />
+  <a href="https://coveralls.io/github/rewiko/crud?branch=master">
+    <img src="https://coveralls.io/repos/github/rewiko/crud/badge.svg" alt="Coverage" />
   </a>
-  <a href="https://github.com/nestjsx/crud/blob/master/LICENSE">
-    <img src="https://img.shields.io/github/license/nestjsx/crud.svg" alt="License" />
+  <a href="https://github.com/rewiko/crud/blob/master/LICENSE">
+    <img src="https://img.shields.io/github/license/rewiko/crud.svg" alt="License" />
   </a>
-  <a href="https://www.npmjs.com/package/@nestjsx/crud">
-    <img src="https://img.shields.io/npm/v/@nestjsx/crud.svg" alt="npm version" />
+  <a href="https://www.npmjs.com/package/@rewiko/crud">
+    <img src="https://img.shields.io/npm/v/@rewiko/crud.svg" alt="npm version" />
   </a>
   <a href="https://www.npmjs.com/org/nestjsx">
-    <img src="https://img.shields.io/npm/dm/@nestjsx/crud.svg" alt="npm downloads" />
+    <img src="https://img.shields.io/npm/dm/@rewiko/crud.svg" alt="npm downloads" />
   </a>
   <a href="https://npm.packagequality.com/#?package=@nestjsx%2Fcrud">
     <img src="https://npm.packagequality.com/shield/%40nestjsx%2Fcrud.svg" alt="Package Quality" />
@@ -33,13 +33,13 @@
     <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square" alt="PRs welcome" />
   </a>
   <a href="https://github.com/marmelab/awesome-rest#nodejs">
-    <img src="https://raw.githubusercontent.com/nestjsx/crud/master/img/awesome-rest.svg?sanitize=true" alt="Awesome REST" />
+    <img src="https://raw.githubusercontent.com/rewiko/crud/master/img/awesome-rest.svg?sanitize=true" alt="Awesome REST" />
   </a>
   <a href="https://github.com/juliandavidmr/awesome-nestjs#components--libraries">
-    <img src="https://raw.githubusercontent.com/nestjsx/crud/master/img/awesome-nest.svg?sanitize=true" alt="Awesome Nest" />
+    <img src="https://raw.githubusercontent.com/rewiko/crud/master/img/awesome-nest.svg?sanitize=true" alt="Awesome Nest" />
   </a>
   <a href="https://github.com/nestjs/nest">
-    <img src="https://raw.githubusercontent.com/nestjsx/crud/master/img/nest-powered.svg?sanitize=true" alt="Nest Powered" />
+    <img src="https://raw.githubusercontent.com/rewiko/crud/master/img/nest-powered.svg?sanitize=true" alt="Nest Powered" />
   </a>
   <a href="#individuals" alt="Sponsors on Open Collective">
     <img src="https://opencollective.com/nestjsx/backers/badge.svg" />
@@ -52,18 +52,18 @@
 <div align="center">
   <sub>Built by
   <a href="https://twitter.com/MichaelYali">@MichaelYali</a> and
-  <a href="https://github.com/nestjsx/crud/graphs/contributors">
+  <a href="https://github.com/rewiko/crud/graphs/contributors">
     Contributors
   </a>
 </div>
 
 <br />
 
-We believe that everyone who's working with NestJs and building some RESTful services and especially some CRUD functionality will find `@nestjsx/crud` microframework very useful.
+We believe that everyone who's working with NestJs and building some RESTful services and especially some CRUD functionality will find `@rewiko/crud` microframework very useful.
 
 ## Features
 
-<img align="right" src="https://raw.githubusercontent.com/nestjsx/crud/master/img/crud-usage2.png" alt="CRUD usage" />
+<img align="right" src="https://raw.githubusercontent.com/rewiko/crud/master/img/crud-usage2.png" alt="CRUD usage" />
 
 - Super easy to install and start using the full-featured controllers and services :point_right:
 
@@ -86,21 +86,21 @@ We believe that everyone who's working with NestJs and building some RESTful ser
 ## Install
 
 ```shell
-npm i @nestjsx/crud-typeorm @nestjs/typeorm typeorm
+npm i @rewiko/crud-typeorm @nestjs/typeorm typeorm
 ```
 
 ## Packages
 
-- [**@nestjsx/crud**](https://www.npmjs.com/package/@nestjsx/crud) - core package which provides `@Crud()` decorator for endpoints generation, global configuration, validation, helper decorators ([docs](https://github.com/nestjsx/crud/wiki/Controllers#description))
-- [**@nestjsx/crud-request**](https://www.npmjs.com/package/@nestjsx/crud-request) - request builder/parser package which provides `RequestQueryBuilder` class for a frontend usage and `RequestQueryParser` that is being used internally for handling and validating query/path params on a backend side ([docs](https://github.com/nestjsx/crud/wiki/Requests#frontend-usage))
-- [**@nestjsx/crud-typeorm**](https://www.npmjs.com/package/@nestjsx/crud-typeorm) - TypeORM package which provides base `TypeOrmCrudService` with methods for CRUD database operations ([docs](https://github.com/nestjsx/crud/wiki/ServiceTypeorm))
+- [**@rewiko/crud**](https://www.npmjs.com/package/@rewiko/crud) - core package which provides `@Crud()` decorator for endpoints generation, global configuration, validation, helper decorators ([docs](https://github.com/rewiko/crud/wiki/Controllers#description))
+- [**@rewiko/crud-request**](https://www.npmjs.com/package/@rewiko/crud-request) - request builder/parser package which provides `RequestQueryBuilder` class for a frontend usage and `RequestQueryParser` that is being used internally for handling and validating query/path params on a backend side ([docs](https://github.com/rewiko/crud/wiki/Requests#frontend-usage))
+- [**@rewiko/crud-typeorm**](https://www.npmjs.com/package/@rewiko/crud-typeorm) - TypeORM package which provides base `TypeOrmCrudService` with methods for CRUD database operations ([docs](https://github.com/rewiko/crud/wiki/ServiceTypeorm))
 
 ## Documentation
 
-- [General Information](https://github.com/nestjsx/crud/wiki#why)
-- [CRUD Controllers](https://github.com/nestjsx/crud/wiki/Controllers#description)
-- [CRUD ORM Services](https://github.com/nestjsx/crud/wiki/Services#description)
-- [Handling Requests](https://github.com/nestjsx/crud/wiki/Requests#description)
+- [General Information](https://github.com/rewiko/crud/wiki#why)
+- [CRUD Controllers](https://github.com/rewiko/crud/wiki/Controllers#description)
+- [CRUD ORM Services](https://github.com/rewiko/crud/wiki/Services#description)
+- [Handling Requests](https://github.com/rewiko/crud/wiki/Requests#description)
 
 ## Support
 
@@ -111,7 +111,7 @@ Any support is welcome. At least you can give us a star.
 ### Code Contributors
 
 This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
-<a href="https://github.com/nestjsx/crud/graphs/contributors"><img src="https://opencollective.com/nestjsx/contributors.svg?width=890&button=false" /></a>
+<a href="https://github.com/rewiko/crud/graphs/contributors"><img src="https://opencollective.com/nestjsx/contributors.svg?width=890&button=false" /></a>
 
 ### Financial Contributors
 

--- a/packages/crud-typeorm/src/typeorm-crud.service.ts
+++ b/packages/crud-typeorm/src/typeorm-crud.service.ts
@@ -7,7 +7,7 @@ import {
   JoinOption,
   JoinOptions,
   QueryOptions,
-} from '@nestjsx/crud';
+} from '@rewiko/crud';
 import {
   ParsedRequestParams,
   QueryFilter,
@@ -16,7 +16,7 @@ import {
   SCondition,
   SConditionKey,
   ComparisonOperator,
-} from '@nestjsx/crud-request';
+} from '@rewiko/crud-request';
 import {
   ClassType,
   hasLength,
@@ -26,7 +26,7 @@ import {
   objKeys,
   isNil,
   isNull,
-} from '@nestjsx/util';
+} from '@rewiko/util';
 import { oO } from '@zmotivat0r/o0';
 import { plainToClass } from 'class-transformer';
 import {

--- a/packages/crud-typeorm/test/b.query-params.spec.ts
+++ b/packages/crud-typeorm/test/b.query-params.spec.ts
@@ -2,7 +2,7 @@ import { Controller, INestApplication } from '@nestjs/common';
 import { APP_FILTER } from '@nestjs/core';
 import { Test } from '@nestjs/testing';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { RequestQueryBuilder } from '@nestjsx/crud-request';
+import { RequestQueryBuilder } from '@rewiko/crud-request';
 import 'jest-extended';
 import * as request from 'supertest';
 

--- a/packages/crud-typeorm/test/c.basic-crud.spec.ts
+++ b/packages/crud-typeorm/test/c.basic-crud.spec.ts
@@ -3,8 +3,8 @@ import { APP_FILTER } from '@nestjs/core';
 import { Test } from '@nestjs/testing';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
-import { Crud } from '@nestjsx/crud';
-import { RequestQueryBuilder } from '@nestjsx/crud-request';
+import { Crud } from '@rewiko/crud';
+import { RequestQueryBuilder } from '@rewiko/crud-request';
 import * as request from 'supertest';
 import { Company } from '../../../integration/crud-typeorm/companies';
 import { Device } from '../../../integration/crud-typeorm/devices';

--- a/packages/crud-typeorm/test/d.crud-auth.spec.ts
+++ b/packages/crud-typeorm/test/d.crud-auth.spec.ts
@@ -9,7 +9,7 @@ import { APP_FILTER, APP_GUARD } from '@nestjs/core';
 import { Test } from '@nestjs/testing';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
-import { Crud, CrudAuth } from '@nestjsx/crud';
+import { Crud, CrudAuth } from '@rewiko/crud';
 import * as request from 'supertest';
 import { withCache } from '../../../integration/crud-typeorm/orm.config';
 import { User } from '../../../integration/crud-typeorm/users';

--- a/packages/crud/README.md
+++ b/packages/crud/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <h1>CRUD (@nestjsx/crud)</h1>
+  <h1>CRUD (@rewiko/crud)</h1>
 </div>
 <div align="center">
   <strong>for RESTful APIs built with NestJs</strong>
@@ -8,20 +8,20 @@
 <br />
 
 <div align="center">
-  <a href="https://travis-ci.org/nestjsx/crud">
-    <img src="https://github.com/nestjsx/crud/workflows/Tests/badge.svg" alt="Build" />
+  <a href="https://travis-ci.org/rewiko/crud">
+    <img src="https://github.com/rewiko/crud/workflows/Tests/badge.svg" alt="Build" />
   </a>
-  <a href="https://coveralls.io/github/nestjsx/crud?branch=master">
-    <img src="https://coveralls.io/repos/github/nestjsx/crud/badge.svg" alt="Coverage" />
+  <a href="https://coveralls.io/github/rewiko/crud?branch=master">
+    <img src="https://coveralls.io/repos/github/rewiko/crud/badge.svg" alt="Coverage" />
   </a>
-  <a href="https://github.com/nestjsx/crud/blob/master/LICENSE">
-    <img src="https://img.shields.io/github/license/nestjsx/crud.svg" alt="License" />
+  <a href="https://github.com/rewiko/crud/blob/master/LICENSE">
+    <img src="https://img.shields.io/github/license/rewiko/crud.svg" alt="License" />
   </a>
-  <a href="https://www.npmjs.com/package/@nestjsx/crud">
-    <img src="https://img.shields.io/npm/v/@nestjsx/crud.svg" alt="npm version" />
+  <a href="https://www.npmjs.com/package/@rewiko/crud">
+    <img src="https://img.shields.io/npm/v/@rewiko/crud.svg" alt="npm version" />
   </a>
   <a href="https://www.npmjs.com/org/nestjsx">
-    <img src="https://img.shields.io/npm/dm/@nestjsx/crud.svg" alt="npm downloads" />
+    <img src="https://img.shields.io/npm/dm/@rewiko/crud.svg" alt="npm downloads" />
   </a>
   <a href="https://npm.packagequality.com/#?package=@nestjsx%2Fcrud">
     <img src="https://npm.packagequality.com/shield/%40nestjsx%2Fcrud.svg" alt="Package Quality" />
@@ -33,13 +33,13 @@
     <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square" alt="PRs welcome" />
   </a>
   <a href="https://github.com/marmelab/awesome-rest#nodejs">
-    <img src="https://raw.githubusercontent.com/nestjsx/crud/master/img/awesome-rest.svg?sanitize=true" alt="Awesome REST" />
+    <img src="https://raw.githubusercontent.com/rewiko/crud/master/img/awesome-rest.svg?sanitize=true" alt="Awesome REST" />
   </a>
   <a href="https://github.com/juliandavidmr/awesome-nestjs#components--libraries">
-    <img src="https://raw.githubusercontent.com/nestjsx/crud/master/img/awesome-nest.svg?sanitize=true" alt="Awesome Nest" />
+    <img src="https://raw.githubusercontent.com/rewiko/crud/master/img/awesome-nest.svg?sanitize=true" alt="Awesome Nest" />
   </a>
   <a href="https://github.com/nestjs/nest">
-    <img src="https://raw.githubusercontent.com/nestjsx/crud/master/img/nest-powered.svg?sanitize=true" alt="Nest Powered" />
+    <img src="https://raw.githubusercontent.com/rewiko/crud/master/img/nest-powered.svg?sanitize=true" alt="Nest Powered" />
   </a>
   <a href="#individuals" alt="Sponsors on Open Collective">
     <img src="https://opencollective.com/nestjsx/backers/badge.svg" />
@@ -52,18 +52,18 @@
 <div align="center">
   <sub>Built by
   <a href="https://twitter.com/MichaelYali">@MichaelYali</a> and
-  <a href="https://github.com/nestjsx/crud/graphs/contributors">
+  <a href="https://github.com/rewiko/crud/graphs/contributors">
     Contributors
   </a>
 </div>
 
 <br />
 
-We believe that everyone who's working with NestJs and building some RESTful services and especially some CRUD functionality will find `@nestjsx/crud` microframework very useful.
+We believe that everyone who's working with NestJs and building some RESTful services and especially some CRUD functionality will find `@rewiko/crud` microframework very useful.
 
 ## Features
 
-<img align="right" src="https://raw.githubusercontent.com/nestjsx/crud/master/img/crud-usage2.png" alt="CRUD usage" />
+<img align="right" src="https://raw.githubusercontent.com/rewiko/crud/master/img/crud-usage2.png" alt="CRUD usage" />
 
 - Super easy to install and start using the full-featured controllers and services :point_right:
 
@@ -86,21 +86,21 @@ We believe that everyone who's working with NestJs and building some RESTful ser
 ## Install
 
 ```shell
-npm i @nestjsx/crud class-transformer class-validator
+npm i @rewiko/crud class-transformer class-validator
 ```
 
 ## Packages
 
-- [**@nestjsx/crud**](https://www.npmjs.com/package/@nestjsx/crud) - core package which provides `@Crud()` decorator for endpoints generation, global configuration, validation, helper decorators ([docs](https://github.com/nestjsx/crud/wiki/Controllers#description))
-- [**@nestjsx/crud-request**](https://www.npmjs.com/package/@nestjsx/crud-request) - request builder/parser package which provides `RequestQueryBuilder` class for a frontend usage and `RequestQueryParser` that is being used internally for handling and validating query/path params on a backend side ([docs](https://github.com/nestjsx/crud/wiki/Requests#frontend-usage))
-- [**@nestjsx/crud-typeorm**](https://www.npmjs.com/package/@nestjsx/crud-typeorm) - TypeORM package which provides base `TypeOrmCrudService` with methods for CRUD database operations ([docs](https://github.com/nestjsx/crud/wiki/ServiceTypeorm))
+- [**@rewiko/crud**](https://www.npmjs.com/package/@rewiko/crud) - core package which provides `@Crud()` decorator for endpoints generation, global configuration, validation, helper decorators ([docs](https://github.com/rewiko/crud/wiki/Controllers#description))
+- [**@rewiko/crud-request**](https://www.npmjs.com/package/@rewiko/crud-request) - request builder/parser package which provides `RequestQueryBuilder` class for a frontend usage and `RequestQueryParser` that is being used internally for handling and validating query/path params on a backend side ([docs](https://github.com/rewiko/crud/wiki/Requests#frontend-usage))
+- [**@rewiko/crud-typeorm**](https://www.npmjs.com/package/@rewiko/crud-typeorm) - TypeORM package which provides base `TypeOrmCrudService` with methods for CRUD database operations ([docs](https://github.com/rewiko/crud/wiki/ServiceTypeorm))
 
 ## Documentation
 
-- [General Information](https://github.com/nestjsx/crud/wiki#why)
-- [CRUD Controllers](https://github.com/nestjsx/crud/wiki/Controllers#description)
-- [CRUD ORM Services](https://github.com/nestjsx/crud/wiki/Services#description)
-- [Handling Requests](https://github.com/nestjsx/crud/wiki/Requests#description)
+- [General Information](https://github.com/rewiko/crud/wiki#why)
+- [CRUD Controllers](https://github.com/rewiko/crud/wiki/Controllers#description)
+- [CRUD ORM Services](https://github.com/rewiko/crud/wiki/Services#description)
+- [Handling Requests](https://github.com/rewiko/crud/wiki/Requests#description)
 
 ## Support
 
@@ -111,7 +111,7 @@ Any support is welcome. At least you can give us a star.
 ### Code Contributors
 
 This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
-<a href="https://github.com/nestjsx/crud/graphs/contributors"><img src="https://opencollective.com/nestjsx/contributors.svg?width=890&button=false" /></a>
+<a href="https://github.com/rewiko/crud/graphs/contributors"><img src="https://opencollective.com/nestjsx/contributors.svg?width=890&button=false" /></a>
 
 ### Financial Contributors
 

--- a/packages/crud/src/crud/crud-routes.factory.ts
+++ b/packages/crud/src/crud/crud-routes.factory.ts
@@ -11,7 +11,7 @@ import {
   getOwnPropNames,
   isNil,
   isUndefined,
-} from '@nestjsx/util';
+} from '@rewiko/util';
 import * as deepmerge from 'deepmerge';
 
 import { R } from './reflection.helper';

--- a/packages/crud/src/crud/reflection.helper.ts
+++ b/packages/crud/src/crud/reflection.helper.ts
@@ -8,7 +8,7 @@ import {
   ROUTE_ARGS_METADATA,
 } from '@nestjs/common/constants';
 import { ArgumentsHost } from '@nestjs/common';
-import { isFunction } from '@nestjsx/util';
+import { isFunction } from '@rewiko/util';
 
 import { BaseRoute, MergedCrudOptions, AuthOptions } from '../interfaces';
 import { BaseRouteName } from '../types';

--- a/packages/crud/src/crud/swagger.helper.ts
+++ b/packages/crud/src/crud/swagger.helper.ts
@@ -1,6 +1,6 @@
 import { HttpStatus } from '@nestjs/common';
-import { RequestQueryBuilder } from '@nestjsx/crud-request';
-import { isString, objKeys } from '@nestjsx/util';
+import { RequestQueryBuilder } from '@rewiko/crud-request';
+import { isString, objKeys } from '@rewiko/util';
 import { MergedCrudOptions, ParamsOptions } from '../interfaces';
 import { BaseRouteName } from '../types';
 import { safeRequire } from '../util';
@@ -273,7 +273,7 @@ export class Swagger {
     } = Swagger.getQueryParamsNames();
     const oldVersion = Swagger.getSwaggerVersion() < 4;
     const docsLink = (a: string) =>
-      `<a href="https://github.com/nestjsx/crud/wiki/Requests#${a}" target="_blank">Docs</a>`;
+      `<a href="https://github.com/rewiko/crud/wiki/Requests#${a}" target="_blank">Docs</a>`;
 
     const fieldsMetaBase = {
       name: fields,

--- a/packages/crud/src/crud/validation.helper.ts
+++ b/packages/crud/src/crud/validation.helper.ts
@@ -1,5 +1,5 @@
 import { ValidationPipe } from '@nestjs/common';
-import { isFalse, isNil } from '@nestjsx/util';
+import { isFalse, isNil } from '@rewiko/util';
 import { CrudValidationGroups } from '../enums';
 import { CreateManyDto, CrudOptions, MergedCrudOptions } from '../interfaces';
 import { safeRequire } from '../util';

--- a/packages/crud/src/interceptors/crud-request.interceptor.ts
+++ b/packages/crud/src/interceptors/crud-request.interceptor.ts
@@ -10,8 +10,8 @@ import {
   RequestQueryParser,
   SCondition,
   QueryFilter,
-} from '@nestjsx/crud-request';
-import { isNil, isFunction, isArrayFull, hasLength } from '@nestjsx/util';
+} from '@rewiko/crud-request';
+import { isNil, isFunction, isArrayFull, hasLength } from '@rewiko/util';
 
 import { PARSED_CRUD_REQUEST_KEY } from '../constants';
 import { CrudActions } from '../enums';

--- a/packages/crud/src/interceptors/crud-response.interceptor.ts
+++ b/packages/crud/src/interceptors/crud-response.interceptor.ts
@@ -4,7 +4,7 @@ import {
   Injectable,
   NestInterceptor,
 } from '@nestjs/common';
-import { isFalse, isObject, isFunction } from '@nestjsx/util';
+import { isFalse, isObject, isFunction } from '@rewiko/util';
 import { classToPlain, classToPlainFromExist } from 'class-transformer';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';

--- a/packages/crud/src/interfaces/auth-options.interface.ts
+++ b/packages/crud/src/interfaces/auth-options.interface.ts
@@ -1,5 +1,5 @@
-import { SCondition } from '@nestjsx/crud-request/lib/types/request-query.types';
-import { ObjectLiteral } from '@nestjsx/util';
+import { SCondition } from '@rewiko/crud-request/lib/types/request-query.types';
+import { ObjectLiteral } from '@rewiko/util';
 
 export interface AuthGlobalOptions {
   property?: string;

--- a/packages/crud/src/interfaces/crud-global-config.interface.ts
+++ b/packages/crud/src/interfaces/crud-global-config.interface.ts
@@ -1,4 +1,4 @@
-import { RequestQueryBuilderOptions } from '@nestjsx/crud-request';
+import { RequestQueryBuilderOptions } from '@rewiko/crud-request';
 
 import { RoutesOptions } from './routes-options.interface';
 import { ParamsOptions } from './params-options.interface';

--- a/packages/crud/src/interfaces/crud-request.interface.ts
+++ b/packages/crud/src/interfaces/crud-request.interface.ts
@@ -1,4 +1,4 @@
-import { ParsedRequestParams } from '@nestjsx/crud-request';
+import { ParsedRequestParams } from '@rewiko/crud-request';
 
 import { CrudRequestOptions } from '../interfaces';
 

--- a/packages/crud/src/interfaces/params-options.interface.ts
+++ b/packages/crud/src/interfaces/params-options.interface.ts
@@ -1,5 +1,5 @@
 import { SwaggerEnumType } from '@nestjs/swagger/dist/types/swagger-enum.type';
-import { ParamOptionType } from '@nestjsx/crud-request';
+import { ParamOptionType } from '@rewiko/crud-request';
 
 export interface ParamsOptions {
   [key: string]: ParamOption;

--- a/packages/crud/src/interfaces/query-options.interface.ts
+++ b/packages/crud/src/interfaces/query-options.interface.ts
@@ -1,7 +1,7 @@
 import {
   QueryFields,
   QuerySort,
-} from '@nestjsx/crud-request/lib/types/request-query.types';
+} from '@rewiko/crud-request/lib/types/request-query.types';
 
 import { QueryFilterOption } from '../types';
 

--- a/packages/crud/src/module/crud-config.service.ts
+++ b/packages/crud/src/module/crud-config.service.ts
@@ -1,5 +1,5 @@
-import { RequestQueryBuilder } from '@nestjsx/crud-request';
-import { isObjectFull } from '@nestjsx/util';
+import { RequestQueryBuilder } from '@rewiko/crud-request';
+import { isObjectFull } from '@rewiko/util';
 import * as deepmerge from 'deepmerge';
 
 import { CrudGlobalConfig } from '../interfaces';

--- a/packages/crud/src/services/crud-service.abstract.ts
+++ b/packages/crud/src/services/crud-service.abstract.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { ParsedRequestParams } from '@nestjsx/crud-request';
-import { objKeys } from '@nestjsx/util';
+import { ParsedRequestParams } from '@rewiko/crud-request';
+import { objKeys } from '@rewiko/util';
 
 import {
   CreateManyDto,

--- a/packages/crud/src/types/query-filter-option.type.ts
+++ b/packages/crud/src/types/query-filter-option.type.ts
@@ -1,7 +1,7 @@
 import {
   QueryFilter,
   SCondition,
-} from '@nestjsx/crud-request/lib/types/request-query.types';
+} from '@rewiko/crud-request/lib/types/request-query.types';
 
 export type QueryFilterFunction = (
   search?: SCondition,

--- a/packages/crud/test/__fixture__/exception.filter.ts
+++ b/packages/crud/test/__fixture__/exception.filter.ts
@@ -1,5 +1,5 @@
 import { ArgumentsHost, Catch, ExceptionFilter, HttpStatus } from '@nestjs/common';
-import { RequestQueryException } from '@nestjsx/crud-request';
+import { RequestQueryException } from '@rewiko/crud-request';
 import { Response } from 'express';
 
 @Catch(RequestQueryException)

--- a/packages/crud/test/__fixture__/services/test.service.ts
+++ b/packages/crud/test/__fixture__/services/test.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { ParsedRequestParams } from '@nestjsx/crud-request';
+import { ParsedRequestParams } from '@rewiko/crud-request';
 import { CrudRequestOptions } from '../../../src/interfaces';
 
 import { CreateManyDto, CrudRequest } from '../../../src/interfaces';

--- a/packages/crud/test/crud-config.service.global.spec.ts
+++ b/packages/crud/test/crud-config.service.global.spec.ts
@@ -35,7 +35,7 @@ const conf: CrudGlobalConfig = {
 };
 
 // Important: load config before (!!!) you import AppModule
-// https://github.com/nestjsx/crud/wiki/Controllers#global-options
+// https://github.com/rewiko/crud/wiki/Controllers#global-options
 CrudConfigService.load(conf);
 
 import { Crud } from '../src/decorators/crud.decorator';

--- a/packages/crud/test/crud-config.service.spec.ts
+++ b/packages/crud/test/crud-config.service.spec.ts
@@ -1,4 +1,4 @@
-import { RequestQueryBuilder } from '@nestjsx/crud-request';
+import { RequestQueryBuilder } from '@rewiko/crud-request';
 import { CrudGlobalConfig } from '../src/interfaces';
 import { CrudConfigService } from '../src/module/crud-config.service';
 

--- a/packages/crud/test/crud-request.interceptor.spec.ts
+++ b/packages/crud/test/crud-request.interceptor.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '@nestjs/common';
 import { NestApplication } from '@nestjs/core';
 import { Test } from '@nestjs/testing';
-import { RequestQueryBuilder } from '@nestjsx/crud-request';
+import { RequestQueryBuilder } from '@rewiko/crud-request';
 import * as supertest from 'supertest';
 import { Crud, ParsedRequest, CrudAuth, Override } from '../src/decorators';
 import { CrudRequestInterceptor } from '../src/interceptors';

--- a/packages/crud/test/crud.decorator.base.spec.ts
+++ b/packages/crud/test/crud.decorator.base.spec.ts
@@ -2,7 +2,7 @@ import * as request from 'supertest';
 import { Test } from '@nestjs/testing';
 import { Controller, INestApplication } from '@nestjs/common';
 import { APP_FILTER } from '@nestjs/core';
-import { RequestQueryBuilder } from '@nestjsx/crud-request';
+import { RequestQueryBuilder } from '@rewiko/crud-request';
 
 import { Crud } from '../src/decorators/crud.decorator';
 import { CreateManyDto } from '../src/interfaces';

--- a/packages/crud/test/crud.decorator.override.spec.ts
+++ b/packages/crud/test/crud.decorator.override.spec.ts
@@ -2,7 +2,7 @@ import * as request from 'supertest';
 import { Test } from '@nestjs/testing';
 import { Controller, INestApplication } from '@nestjs/common';
 import { APP_FILTER } from '@nestjs/core';
-import { RequestQueryBuilder } from '@nestjsx/crud-request';
+import { RequestQueryBuilder } from '@rewiko/crud-request';
 
 import { Crud, Override, ParsedRequest, ParsedBody } from '../src/decorators';
 import { CrudController, CrudRequest, CreateManyDto } from '../src/interfaces';

--- a/packages/util/README.md
+++ b/packages/util/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <h1>CRUD (@nestjsx/util)</h1>
+  <h1>CRUD (@rewiko/util)</h1>
 </div>
 <div align="center">
   <strong>for RESTful APIs built with NestJs</strong>
@@ -8,20 +8,20 @@
 <br />
 
 <div align="center">
-  <a href="https://travis-ci.org/nestjsx/crud">
-    <img src="https://github.com/nestjsx/crud/workflows/Tests/badge.svg" alt="Build" />
+  <a href="https://travis-ci.org/rewiko/crud">
+    <img src="https://github.com/rewiko/crud/workflows/Tests/badge.svg" alt="Build" />
   </a>
-  <a href="https://coveralls.io/github/nestjsx/crud?branch=master">
-    <img src="https://coveralls.io/repos/github/nestjsx/crud/badge.svg" alt="Coverage" />
+  <a href="https://coveralls.io/github/rewiko/crud?branch=master">
+    <img src="https://coveralls.io/repos/github/rewiko/crud/badge.svg" alt="Coverage" />
   </a>
-  <a href="https://github.com/nestjsx/crud/blob/master/LICENSE">
-    <img src="https://img.shields.io/github/license/nestjsx/crud.svg" alt="License" />
+  <a href="https://github.com/rewiko/crud/blob/master/LICENSE">
+    <img src="https://img.shields.io/github/license/rewiko/crud.svg" alt="License" />
   </a>
-  <a href="https://www.npmjs.com/package/@nestjsx/crud">
-    <img src="https://img.shields.io/npm/v/@nestjsx/crud.svg" alt="npm version" />
+  <a href="https://www.npmjs.com/package/@rewiko/crud">
+    <img src="https://img.shields.io/npm/v/@rewiko/crud.svg" alt="npm version" />
   </a>
   <a href="https://www.npmjs.com/org/nestjsx">
-    <img src="https://img.shields.io/npm/dm/@nestjsx/crud.svg" alt="npm downloads" />
+    <img src="https://img.shields.io/npm/dm/@rewiko/crud.svg" alt="npm downloads" />
   </a>
   <a href="https://npm.packagequality.com/#?package=@nestjsx%2Fcrud">
     <img src="https://npm.packagequality.com/shield/%40nestjsx%2Fcrud.svg" alt="Package Quality" />
@@ -33,13 +33,13 @@
     <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square" alt="PRs welcome" />
   </a>
   <a href="https://github.com/marmelab/awesome-rest#nodejs">
-    <img src="https://raw.githubusercontent.com/nestjsx/crud/master/img/awesome-rest.svg?sanitize=true" alt="Awesome REST" />
+    <img src="https://raw.githubusercontent.com/rewiko/crud/master/img/awesome-rest.svg?sanitize=true" alt="Awesome REST" />
   </a>
   <a href="https://github.com/juliandavidmr/awesome-nestjs#components--libraries">
-    <img src="https://raw.githubusercontent.com/nestjsx/crud/master/img/awesome-nest.svg?sanitize=true" alt="Awesome Nest" />
+    <img src="https://raw.githubusercontent.com/rewiko/crud/master/img/awesome-nest.svg?sanitize=true" alt="Awesome Nest" />
   </a>
   <a href="https://github.com/nestjs/nest">
-    <img src="https://raw.githubusercontent.com/nestjsx/crud/master/img/nest-powered.svg?sanitize=true" alt="Nest Powered" />
+    <img src="https://raw.githubusercontent.com/rewiko/crud/master/img/nest-powered.svg?sanitize=true" alt="Nest Powered" />
   </a>
   <a href="#individuals" alt="Sponsors on Open Collective">
     <img src="https://opencollective.com/nestjsx/backers/badge.svg" />
@@ -52,18 +52,18 @@
 <div align="center">
   <sub>Built by
   <a href="https://twitter.com/MichaelYali">@MichaelYali</a> and
-  <a href="https://github.com/nestjsx/crud/graphs/contributors">
+  <a href="https://github.com/rewiko/crud/graphs/contributors">
     Contributors
   </a>
 </div>
 
 <br />
 
-We believe that everyone who's working with NestJs and building some RESTful services and especially some CRUD functionality will find `@nestjsx/crud` microframework very useful.
+We believe that everyone who's working with NestJs and building some RESTful services and especially some CRUD functionality will find `@rewiko/crud` microframework very useful.
 
 ## Features
 
-<img align="right" src="https://raw.githubusercontent.com/nestjsx/crud/master/img/crud-usage2.png" alt="CRUD usage" />
+<img align="right" src="https://raw.githubusercontent.com/rewiko/crud/master/img/crud-usage2.png" alt="CRUD usage" />
 
 - Super easy to install and start using the full-featured controllers and services :point_right:
 
@@ -85,16 +85,16 @@ We believe that everyone who's working with NestJs and building some RESTful ser
 
 ## Packages
 
-- [**@nestjsx/crud**](https://www.npmjs.com/package/@nestjsx/crud) - core package which provides `@Crud()` decorator for endpoints generation, global configuration, validation, helper decorators ([docs](https://github.com/nestjsx/crud/wiki/Controllers#description))
-- [**@nestjsx/crud-request**](https://www.npmjs.com/package/@nestjsx/crud-request) - request builder/parser package which provides `RequestQueryBuilder` class for a frontend usage and `RequestQueryParser` that is being used internally for handling and validating query/path params on a backend side ([docs](https://github.com/nestjsx/crud/wiki/Requests#frontend-usage))
-- [**@nestjsx/crud-typeorm**](https://www.npmjs.com/package/@nestjsx/crud-typeorm) - TypeORM package which provides base `TypeOrmCrudService` with methods for CRUD database operations ([docs](https://github.com/nestjsx/crud/wiki/ServiceTypeorm))
+- [**@rewiko/crud**](https://www.npmjs.com/package/@rewiko/crud) - core package which provides `@Crud()` decorator for endpoints generation, global configuration, validation, helper decorators ([docs](https://github.com/rewiko/crud/wiki/Controllers#description))
+- [**@rewiko/crud-request**](https://www.npmjs.com/package/@rewiko/crud-request) - request builder/parser package which provides `RequestQueryBuilder` class for a frontend usage and `RequestQueryParser` that is being used internally for handling and validating query/path params on a backend side ([docs](https://github.com/rewiko/crud/wiki/Requests#frontend-usage))
+- [**@rewiko/crud-typeorm**](https://www.npmjs.com/package/@rewiko/crud-typeorm) - TypeORM package which provides base `TypeOrmCrudService` with methods for CRUD database operations ([docs](https://github.com/rewiko/crud/wiki/ServiceTypeorm))
 
 ## Documentation
 
-- [General Information](https://github.com/nestjsx/crud/wiki#why)
-- [CRUD Controllers](https://github.com/nestjsx/crud/wiki/Controllers#description)
-- [CRUD ORM Services](https://github.com/nestjsx/crud/wiki/Services#description)
-- [Handling Requests](https://github.com/nestjsx/crud/wiki/Requests#description)
+- [General Information](https://github.com/rewiko/crud/wiki#why)
+- [CRUD Controllers](https://github.com/rewiko/crud/wiki/Controllers#description)
+- [CRUD ORM Services](https://github.com/rewiko/crud/wiki/Services#description)
+- [Handling Requests](https://github.com/rewiko/crud/wiki/Requests#description)
 
 ## Support
 
@@ -105,7 +105,7 @@ Any support is welcome. At least you can give us a star.
 ### Code Contributors
 
 This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
-<a href="https://github.com/nestjsx/crud/graphs/contributors"><img src="https://opencollective.com/nestjsx/contributors.svg?width=890&button=false" /></a>
+<a href="https://github.com/rewiko/crud/graphs/contributors"><img src="https://opencollective.com/nestjsx/contributors.svg?width=890&button=false" /></a>
 
 ### Financial Contributors
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,14 +15,14 @@
     "composite": true,
     "baseUrl": "./packages",
     "paths": {
-      "@nestjsx/crud": ["crud/src"],
-      "@nestjsx/crud-typeorm": ["crud-typeorm/src"],
-      "@nestjsx/crud-request": ["crud-request/src"],
-      "@nestjsx/util": ["util/src"],
-      "@nestjsx/crud/*": ["crud/src/*"],
-      "@nestjsx/crud-typeorm/*": ["crud-typeorm/src/*"],
-      "@nestjsx/crud-request/*": ["crud-request/src/*"],
-      "@nestjsx/util/*": ["util/src/*"]
+      "@rewiko/crud": ["crud/src"],
+      "@rewiko/crud-typeorm": ["crud-typeorm/src"],
+      "@rewiko/crud-request": ["crud-request/src"],
+      "@rewiko/util": ["util/src"],
+      "@rewiko/crud/*": ["crud/src/*"],
+      "@rewiko/crud-typeorm/*": ["crud-typeorm/src/*"],
+      "@rewiko/crud-request/*": ["crud-request/src/*"],
+      "@rewiko/util/*": ["util/src/*"]
     }
   },
   "references": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -7322,7 +7322,7 @@ please-upgrade-node@^3.2.0:
   dependencies:
     semver-compare "^1.0.0"
 
-pluralize@8.0.0:
+pluralize@8.0.0, pluralize@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
   integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==


### PR DESCRIPTION
Migrate repo from nestjsx to rewiko, because the repo has been unfortunately inactive for too long. see https://github.com/nestjsx/crud/issues/710