### PR TITLE
fix: duplicate column selection

### DIFF
--- a/packages/crud-typeorm/src/typeorm-crud.service.ts
+++ b/packages/crud-typeorm/src/typeorm-crud.service.ts
@@ -631,9 +631,11 @@ export class TypeOrmCrudService<T> extends CrudService<T, DeepPartial<T>> {
         : allowedRelation.allowedColumns;
 
       const select = [
-        ...allowedRelation.primaryColumns,
-        ...(isArrayFull(options.persist) ? options.persist : []),
-        ...columns,
+        ...new Set([
+          ...allowedRelation.primaryColumns,
+          ...(isArrayFull(options.persist) ? options.persist : []),
+          ...columns,
+        ]),
       ].map((col) => `${alias}.${col}`);
 
       builder.addSelect(select);
@@ -946,9 +948,11 @@ export class TypeOrmCrudService<T> extends CrudService<T, DeepPartial<T>> {
         : allowed;
 
     const select = [
-      ...(options.persist && options.persist.length ? options.persist : []),
-      ...columns,
-      ...this.entityPrimaryColumns,
+      ...new Set([
+        ...(options.persist && options.persist.length ? options.persist : []),
+        ...columns,
+        ...this.entityPrimaryColumns,
+      ]),
     ].map((col) => `${this.alias}.${col}`);
 
     return select;


### PR DESCRIPTION
Inspired by https://github.com/nestjsx/crud/issues/788

I don't want to exclude "id" for all relational cases.
I think we just need to remove the duplication in the column array.
Please take a look at it to solve this problem.
Thanks.